### PR TITLE
Set headers before status

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ app.use('/delete', require('./routes/delete'));
 
 app.use(function(err, req, res, next) {
   console.error(err.stack);
-  res.status(500).render('error');
+  res.render('error').status(500);
 });
 
 app.use(function(req, res, next){


### PR DESCRIPTION
Prevents

```
Error: Can't set headers after they are sent.
    at ServerResponse.OutgoingMessage.setHeader (_http_outgoing.js:333:11)
    at ServerResponse.header (/home/janis/src/lolinks/node_modules/express/lib/response.js:700:10)
    at ServerResponse.send (/home/janis/src/lolinks/node_modules/express/lib/response.js:154:12)
    at fn (/home/janis/src/lolinks/node_modules/express/lib/response.js:934:10)
    at View.exports.renderFile [as engine] (/home/janis/src/lolinks/node_modules/jade/lib/index.js:374:12)
    at View.render (/home/janis/src/lolinks/node_modules/express/lib/view.js:93:8)
    at EventEmitter.app.render (/home/janis/src/lolinks/node_modules/express/lib/application.js:566:10)
    at ServerResponse.res.render (/home/janis/src/lolinks/node_modules/express/lib/response.js:938:7)
    at /home/janis/src/lolinks/index.js:59:19
    at Layer.handle_error (/home/janis/src/lolinks/node_modules/express/lib/router/layer.js:58:5)
    at trim_prefix (/home/janis/src/lolinks/node_modules/express/lib/router/index.js:300:13)
    at /home/janis/src/lolinks/node_modules/express/lib/router/index.js:270:7
    at Function.proto.process_params (/home/janis/src/lolinks/node_modules/express/lib/router/index.js:321:12)
    at Immediate.next (/home/janis/src/lolinks/node_modules/express/lib/router/index.js:261:10)
    at Immediate.<anonymous> (/home/janis/src/lolinks/node_modules/express/lib/router/index.js:603:15)
    at Immediate.immediate._onImmediate (timers.js:420:18)

```
